### PR TITLE
FLUT-7164 - [Others] Used path_provider_foundation instead of path_provider_macOS

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   url_launcher: ^6.1.0
   path_provider: ^2.0.1
-  path_provider_macos: ^2.0.0
+  path_provider_foundation: ^2.1.0
   desktop_window: 0.4.0
   intl: ^0.17.0
 


### PR DESCRIPTION
Recently, [path_provider_macos](https://pub.dev/packages/path_provider_macos) has been discontinued and replaced with [path_provider_foundation](https://pub.dev/packages/path_provider_foundation). So, used path_provider_foundation instead of path_provider_macOS.