### PR TITLE
FLUT-922317 - [Others] Updated the trademark symbol

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Syncfusion License
 
-Syncfusion Essential Flutter library is available under the Syncfusion Essential Studio program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
+Syncfusion Essential Flutter library is available under the Syncfusion Essential Studio<sup>&reg;</sup> program, and can be licensed either under the Syncfusion Community License Program or the Syncfusion commercial license.
 
 To be qualified for the Syncfusion Community License Program you must have a gross revenue of less than one (1) million U.S. dollars ($1,000,000.00 USD) per year and have less than five (5) developers in your organization, and agree to be bound by Syncfusion’s terms and conditions. 
  


### PR DESCRIPTION
## Description ##

Updated the trademark symbol for the Essential Studio word in the License file of the Flutter Examples public repository.

**Before:**
![image](https://github.com/user-attachments/assets/dc0416ca-a4e0-4e38-9471-45f3a79a113c)


**After:**
![image](https://github.com/user-attachments/assets/066de75a-3e9d-47bb-b319-4eccaedaef03)
