### PR TITLE
FLUT-988135 - [Others] Provided a server permission in macOS platform in debug mode

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,7 +10,7 @@
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<!--The below configuration is added to access the network for Maps samples-->
-	<key>com.apple.security.network.client</key>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description ##

Due to the server permission is not allowed in the macOS platform in Debug mode the application couldn't able to run. So, we have provided a permission to access the external link to load data into an application.

### Before: ### 
<img width="1200" height="196" alt="image" src="https://github.com/user-attachments/assets/1eda75aa-26f6-45fe-8130-f3d71dbe8c6f" />

<img width="2880" height="1588" alt="image" src="https://github.com/user-attachments/assets/c993c9a5-e16c-48b0-9552-7fb66086404a" />


## After: ##

<img width="1248" height="202" alt="image" src="https://github.com/user-attachments/assets/e1d70638-150d-418a-9f40-77fd192e075a" />

<img width="2880" height="1582" alt="image" src="https://github.com/user-attachments/assets/1c6965e9-3729-465a-b5fd-05dc1e2fdbc5" />
